### PR TITLE
Added Buck builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.o
 build/
 docs/_build
+/buck-out/
+/.buckd/
+/buckaroo/
+.buckconfig.local
+BUCKAROO_DEPS

--- a/BUCK
+++ b/BUCK
@@ -1,0 +1,11 @@
+prebuilt_cxx_library(
+  name = 'termcolor',
+  header_only = True,
+  header_namespace = 'termcolor',
+  exported_headers = subdir_glob([
+    ('include/termcolor', '**/*.hpp'),
+  ]),
+  visibility = [
+    'PUBLIC',
+  ],
+)

--- a/buckaroo.json
+++ b/buckaroo.json
@@ -1,0 +1,4 @@
+{
+  "name": "termcolor",
+  "dependencies": {}
+}

--- a/test/BUCK
+++ b/test/BUCK
@@ -1,0 +1,9 @@
+cxx_binary(
+  name = 'test',
+  srcs = [
+    'test.cpp',
+  ],
+  deps = [
+    '//:termcolor',
+  ],
+)


### PR DESCRIPTION
This PR adds support for builds using [Buck](https://buckbuild.com/). 

To run the test:

```
buck run test/
```

The existing CMake build is unchanged; the two can coexist peacefully 😊