### PR TITLE
add install step and config generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,64 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 project(termcolor)
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-  set(CMAKE_CXX_FLAGS "-Werror -Wall -pedantic")
+# define target to install and link tests against
+add_library(${CMAKE_PROJECT_NAME} INTERFACE)
+target_include_directories(${CMAKE_PROJECT_NAME}
+  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+
+# ALIAS same as in configure file
+# the ALIAS can be used to create examples which use the same syntax as a client
+# application, which uses `find_package(libdivide CONFIG)`
+# create the alias libdivide::libdivide
+add_library(${CMAKE_PROJECT_NAME}::${CMAKE_PROJECT_NAME} ALIAS ${CMAKE_PROJECT_NAME})
+
+option(ENABLE_TESTING "enable testing with CTEST" ON)
+if(ENABLE_TESTING)
+  enable_testing()
+  add_executable(test_${CMAKE_PROJECT_NAME} test/test.cpp)
+  # add compiler flags for test target only for GCC and Clang
+  target_compile_options(test_${CMAKE_PROJECT_NAME} INTERFACE
+    $<BUILD_INTERFACE:
+      $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:
+        -Werror -Wall -pedantic>>
+    )
+
+  add_test(test_${CMAKE_PROJECT_NAME} test_${CMAKE_PROJECT_NAME})
+  target_link_libraries(test_${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_PROJECT_NAME}::${CMAKE_PROJECT_NAME})
+  add_custom_target(run COMMAND test_${CMAKE_PROJECT_NAME})
 endif()
 
-include_directories(${termcolor_SOURCE_DIR}/include)
-add_executable(test_${CMAKE_PROJECT_NAME} test/test.cpp)
-add_custom_target(run COMMAND test_${CMAKE_PROJECT_NAME})
+# create install target
+install(
+  TARGETS ${CMAKE_PROJECT_NAME}
+  EXPORT ${CMAKE_PROJECT_NAME}-targets
+  INCLUDES DESTINATION include # set include path for installed library target
+  )
+install(
+  FILES include/termcolor/termcolor.hpp
+  DESTINATION include/termcolor
+  )
+
+# Include module for fuctions
+# - 'write_basic_package_version_file'
+# - 'configure_package_config_file'
+include(CMakePackageConfigHelpers)
+
+# generate and install termcolor-config.cmake file
+# Configure '<PROJECT-NAME>-config.cmake'
+configure_package_config_file(
+  "cmake/config.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/generated/termcolor-config.cmake"
+  INSTALL_DESTINATION "lib/cmake/termcolor"
+)
+# install config file
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/generated/termcolor-config.cmake"
+  DESTINATION "lib/cmake/termcolor"
+)
+# install targets file
+install(
+  EXPORT "${CMAKE_PROJECT_NAME}-targets"
+  NAMESPACE "${CMAKE_PROJECT_NAME}::"
+  DESTINATION "lib/cmake/termcolor"
+)

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@CMAKE_PROJECT_NAME@-targets.cmake")
+check_required_components("@CMAKE_PROJECT_NAME@")
+


### PR DESCRIPTION
- Add interface library for termcolor and add it to install target
- Add ability to toggle creation of tests
- Add test target
- Generate termcolor-config.cmake and install it
    - Make it possible to use termcolor with find_package in other projects
- Add alias termcolor::termcolor to match the installed target name
    - Make it possible to add termcolor as subproject in other projects
- Require CMake 3.0 for INTERFACE library

These changes would make it trivial to add this Package to [Hunter](https://github.com/ruslo/hunter/issues/1482)