### PR TITLE
Add CMake usage examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,103 @@
 sudo: false
 language: cpp
 
-os:
-  - linux
-  - osx
-
-compiler:
-  - clang
-  - gcc
+before_install:
+  - eval "CXX=${COMPILER}"
 
 script:
   - cmake .
   - make
   - make run
+
+jobs:
+  include:
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages: g++-5
+      env: COMPILER="g++-5"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages: g++-6
+      env: COMPILER="g++-6"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages: g++-7
+      env: COMPILER="g++-7"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.8
+          packages: clang-3.8
+      env: COMPILER="clang++-3.8"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-3.9
+          packages: clang-3.9
+      env: COMPILER="clang++-3.9"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-4.0
+          packages: clang-4.0
+      env: COMPILER="clang++-4.0"
+
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-5.0
+          packages: clang-5.0
+      env: COMPILER="clang++-5.0"
+
+    - os: osx
+      osx_image: xcode8.3
+
+    - os: osx
+      osx_image: xcode9.4
+
+    - os: osx
+      osx_image: xcode10
+
+    - script:
+        - mkdir -p /tmp/termcolor && cd "$_"
+        - cmake $TRAVIS_BUILD_DIR
+        - sudo make install
+
+        - mkdir -p /tmp/example && cd "$_"
+        - cmake $TRAVIS_BUILD_DIR/examples/cmake-package
+        - make && ./example
+      name: cmake package
+
+    - script:
+        - mkdir -p /tmp/example && cd "$_"
+        - cmake $TRAVIS_BUILD_DIR/examples/cmake-submodule
+        - make && ./example
+      name: cmake submodule
+
+    - script:
+        - mkdir -p /tmp/example && cd "$_"
+        - cmake $TRAVIS_BUILD_DIR/examples/cmake-external
+        - make && ./example
+      name: cmake external
 
 notifications:
   email: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,36 +2,36 @@ cmake_minimum_required(VERSION 3.0)
 project(termcolor)
 
 # define target to install and link tests against
-add_library(${CMAKE_PROJECT_NAME} INTERFACE)
-target_include_directories(${CMAKE_PROJECT_NAME}
+add_library(${PROJECT_NAME} INTERFACE)
+target_include_directories(${PROJECT_NAME}
   INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
 # ALIAS same as in configure file
 # the ALIAS can be used to create examples which use the same syntax as a client
 # application, which uses `find_package(libdivide CONFIG)`
 # create the alias libdivide::libdivide
-add_library(${CMAKE_PROJECT_NAME}::${CMAKE_PROJECT_NAME} ALIAS ${CMAKE_PROJECT_NAME})
+add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 option(ENABLE_TESTING "enable testing with CTEST" ON)
 if(ENABLE_TESTING)
   enable_testing()
-  add_executable(test_${CMAKE_PROJECT_NAME} test/test.cpp)
+  add_executable(test_${PROJECT_NAME} test/test.cpp)
   # add compiler flags for test target only for GCC and Clang
-  target_compile_options(test_${CMAKE_PROJECT_NAME} INTERFACE
+  target_compile_options(test_${PROJECT_NAME} INTERFACE
     $<BUILD_INTERFACE:
       $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:
         -Werror -Wall -pedantic>>
     )
 
-  add_test(test_${CMAKE_PROJECT_NAME} test_${CMAKE_PROJECT_NAME})
-  target_link_libraries(test_${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_PROJECT_NAME}::${CMAKE_PROJECT_NAME})
-  add_custom_target(run COMMAND test_${CMAKE_PROJECT_NAME})
+  add_test(test_${PROJECT_NAME} test_${PROJECT_NAME})
+  target_link_libraries(test_${PROJECT_NAME} PRIVATE ${PROJECT_NAME}::${PROJECT_NAME})
+  add_custom_target(run COMMAND test_${PROJECT_NAME})
 endif()
 
 # create install target
 install(
-  TARGETS ${CMAKE_PROJECT_NAME}
-  EXPORT ${CMAKE_PROJECT_NAME}-targets
+  TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}-targets
   INCLUDES DESTINATION include # set include path for installed library target
   )
 install(
@@ -58,7 +58,7 @@ install(
 )
 # install targets file
 install(
-  EXPORT "${CMAKE_PROJECT_NAME}-targets"
-  NAMESPACE "${CMAKE_PROJECT_NAME}::"
+  EXPORT "${PROJECT_NAME}-targets"
+  NAMESPACE "${PROJECT_NAME}::"
   DESTINATION "lib/cmake/termcolor"
 )

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -2,4 +2,3 @@
 
 include("${CMAKE_CURRENT_LIST_DIR}/@CMAKE_PROJECT_NAME@-targets.cmake")
 check_required_components("@CMAKE_PROJECT_NAME@")
-

--- a/examples/cmake-external/CMakeLists.txt
+++ b/examples/cmake-external/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.0)
+project(example)
+
+include(ExternalProject)
+
+ExternalProject_Add(termcolor_project
+  GIT_REPOSITORY git://github.com/ikalnytskyi/termcolor.git
+  GIT_TAG origin/master
+
+  # Termcolor is a header-only library which means we need to
+  # neither configure nor build nor install it. Thus, noop
+  # the hooks.
+  CONFIGURE_COMMAND "" BUILD_COMMAND "" INSTALL_COMMAND "")
+ExternalProject_Get_Property(termcolor_project SOURCE_DIR)
+include_directories(${SOURCE_DIR}/include)
+add_library(termcolor INTERFACE IMPORTED)
+add_dependencies(termcolor termcolor_project)
+
+add_executable(${CMAKE_PROJECT_NAME} example.cpp)
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE termcolor)

--- a/examples/cmake-external/example.cpp
+++ b/examples/cmake-external/example.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+#include <termcolor/termcolor.hpp>
+
+int main(int /* argc */, char** /* argv */) {
+    std::cout
+        << termcolor::yellow << "Warm welcome to "
+        << termcolor::blue << termcolor::underline << "TERMCOLOR"
+        << termcolor::reset << std::endl;
+    return 0;
+}

--- a/examples/cmake-package/CMakeLists.txt
+++ b/examples/cmake-package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.0)
+project(example)
+
+find_package(termcolor REQUIRED)
+
+add_executable(${CMAKE_PROJECT_NAME} example.cpp)
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE termcolor::termcolor)

--- a/examples/cmake-package/example.cpp
+++ b/examples/cmake-package/example.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+#include <termcolor/termcolor.hpp>
+
+int main(int /* argc */, char** /* argv */) {
+    std::cout
+        << termcolor::yellow << "Warm welcome to "
+        << termcolor::blue << termcolor::underline << "TERMCOLOR"
+        << termcolor::reset << std::endl;
+    return 0;
+}

--- a/examples/cmake-submodule/CMakeLists.txt
+++ b/examples/cmake-submodule/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.0)
+project(example)
+
+add_subdirectory(../.. ${CMAKE_CURRENT_BINARY_DIR}/termcolor)
+
+add_executable(${CMAKE_PROJECT_NAME} example.cpp)
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE termcolor::termcolor)

--- a/examples/cmake-submodule/example.cpp
+++ b/examples/cmake-submodule/example.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+#include <termcolor/termcolor.hpp>
+
+int main(int /* argc */, char** /* argv */) {
+    std::cout
+        << termcolor::yellow << "Warm welcome to "
+        << termcolor::blue << termcolor::underline << "TERMCOLOR"
+        << termcolor::reset << std::endl;
+    return 0;
+}


### PR DESCRIPTION
CMake is a popular tool among C++ developers, however, not trivial and
covered with poor documentation. That's why it would be nice to provide
a couple of good examples of how one can use termcolor library by
utilizing CMake features. Besides, these examples could be used on CI to
ensure usecases are not broken.