### PR TITLE
Add CMake example using FetchContent module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,13 @@ jobs:
       name: cmake package
 
     - script:
+        - sudo pip install cmake
+        - mkdir -p /tmp/example && cd "$_"
+        - /usr/local/bin/cmake $TRAVIS_BUILD_DIR/examples/cmake-fetch
+        - make && ./example
+      name: cmake fetch
+
+    - script:
         - mkdir -p /tmp/example && cd "$_"
         - cmake $TRAVIS_BUILD_DIR/examples/cmake-submodule
         - make && ./example

--- a/examples/cmake-fetch/CMakeLists.txt
+++ b/examples/cmake-fetch/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.11)
+project(example)
+
+include(FetchContent)
+
+FetchContent_Declare(termcolor
+  GIT_REPOSITORY git://github.com/ikalnytskyi/termcolor.git
+  GIT_TAG origin/master)
+FetchContent_GetProperties(termcolor)
+
+if(NOT termcolor_POPULATED)
+  FetchContent_Populate(termcolor)
+  add_subdirectory(${termcolor_SOURCE_DIR} ${termcolor_BINARY_DIR})
+endif()
+
+add_executable(${CMAKE_PROJECT_NAME} example.cpp)
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE termcolor)

--- a/examples/cmake-fetch/example.cpp
+++ b/examples/cmake-fetch/example.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+#include <termcolor/termcolor.hpp>
+
+int main(int /* argc */, char** /* argv */) {
+    std::cout
+        << termcolor::yellow << "Warm welcome to "
+        << termcolor::blue << termcolor::underline << "TERMCOLOR"
+        << termcolor::reset << std::endl;
+    return 0;
+}


### PR DESCRIPTION
FetchContent module populating content at configure time via any method
supported by the ExternalProject module. Whereas ExternalProject_Add()
downloads at build time, the FetchContent module makes content available
immediately, allowing the configure step to use the content in commands
like add_subdirectory(), include() or file() operations.

In other words this is a modern way to use external libraries in your
projects.