### PR TITLE
Reformat CMakeLists.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 sudo: false
 language: cpp
 
-before_install:
-  - eval "CXX=${COMPILER}"
-
 script:
-  - cmake .
+  - eval "CXX=${COMPILER}"
+  - cmake -DTERMCOLOR_TESTS=ON .
   - make
-  - make run
+  - ./test_termcolor
 
 jobs:
   include:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,64 +1,58 @@
 cmake_minimum_required(VERSION 3.0)
 project(termcolor)
 
-# define target to install and link tests against
-add_library(${PROJECT_NAME} INTERFACE)
-target_include_directories(${PROJECT_NAME}
-  INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+#
+# target
+#
 
-# ALIAS same as in configure file
-# the ALIAS can be used to create examples which use the same syntax as a client
-# application, which uses `find_package(libdivide CONFIG)`
-# create the alias libdivide::libdivide
+add_library(${PROJECT_NAME} INTERFACE)
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
-option(ENABLE_TESTING "enable testing with CTEST" ON)
-if(ENABLE_TESTING)
-  enable_testing()
+target_include_directories(${PROJECT_NAME} INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+
+#
+# tests
+#
+
+option(TERMCOLOR_TESTS "Build termcolor tests." OFF)
+
+if(TERMCOLOR_TESTS)
   add_executable(test_${PROJECT_NAME} test/test.cpp)
-  # add compiler flags for test target only for GCC and Clang
   target_compile_options(test_${PROJECT_NAME} INTERFACE
     $<BUILD_INTERFACE:
       $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:
-        -Werror -Wall -pedantic>>
-    )
-
-  add_test(test_${PROJECT_NAME} test_${PROJECT_NAME})
-  target_link_libraries(test_${PROJECT_NAME} PRIVATE ${PROJECT_NAME}::${PROJECT_NAME})
-  add_custom_target(run COMMAND test_${PROJECT_NAME})
+        -Werror -Wall -pedantic>>)
+  target_link_libraries(
+    test_${PROJECT_NAME} PRIVATE ${PROJECT_NAME}::${PROJECT_NAME})
 endif()
 
-# create install target
+#
+# install
+#
+
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+  cmake/config.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/generated/${PROJECT_NAME}-config.cmake
+  INSTALL_DESTINATION lib/cmake/${PROJECT_NAME})
+
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/generated/${PROJECT_NAME}-config.cmake
+  DESTINATION lib/cmake/${PROJECT_NAME})
+
+install(
+  DIRECTORY include/
+  DESTINATION include)
+
 install(
   TARGETS ${PROJECT_NAME}
   EXPORT ${PROJECT_NAME}-targets
-  INCLUDES DESTINATION include # set include path for installed library target
-  )
-install(
-  FILES include/termcolor/termcolor.hpp
-  DESTINATION include/termcolor
-  )
+  INCLUDES DESTINATION include)
 
-# Include module for fuctions
-# - 'write_basic_package_version_file'
-# - 'configure_package_config_file'
-include(CMakePackageConfigHelpers)
-
-# generate and install termcolor-config.cmake file
-# Configure '<PROJECT-NAME>-config.cmake'
-configure_package_config_file(
-  "cmake/config.cmake.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/generated/termcolor-config.cmake"
-  INSTALL_DESTINATION "lib/cmake/termcolor"
-)
-# install config file
 install(
-  FILES "${CMAKE_CURRENT_BINARY_DIR}/generated/termcolor-config.cmake"
-  DESTINATION "lib/cmake/termcolor"
-)
-# install targets file
-install(
-  EXPORT "${PROJECT_NAME}-targets"
-  NAMESPACE "${PROJECT_NAME}::"
-  DESTINATION "lib/cmake/termcolor"
-)
+  EXPORT ${PROJECT_NAME}-targets
+  NAMESPACE ${PROJECT_NAME}::
+  DESTINATION lib/cmake/${PROJECT_NAME})


### PR DESCRIPTION
To make it simpler and easier to understand.

 * No unnecessary comments.
 * Calls are grouped by their purpose.
 * `make run` target is removed because its name is too general and
   termcolor can be used as a CMake submodule.