### PR TITLE
Add EXCLUDE_FROM_ALL to some examples

### DIFF
--- a/examples/cmake-fetch/CMakeLists.txt
+++ b/examples/cmake-fetch/CMakeLists.txt
@@ -10,7 +10,7 @@ FetchContent_GetProperties(termcolor)
 
 if(NOT termcolor_POPULATED)
   FetchContent_Populate(termcolor)
-  add_subdirectory(${termcolor_SOURCE_DIR} ${termcolor_BINARY_DIR})
+  add_subdirectory(${termcolor_SOURCE_DIR} ${termcolor_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 
 add_executable(${CMAKE_PROJECT_NAME} example.cpp)

--- a/examples/cmake-submodule/CMakeLists.txt
+++ b/examples/cmake-submodule/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 project(example)
 
-add_subdirectory(../.. ${CMAKE_CURRENT_BINARY_DIR}/termcolor)
+add_subdirectory(../.. ${CMAKE_CURRENT_BINARY_DIR}/termcolor EXCLUDE_FROM_ALL)
 
 add_executable(${CMAKE_PROJECT_NAME} example.cpp)
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE termcolor::termcolor)


### PR DESCRIPTION
If EXCLUDE_FROM_ALL is not passed, termcolor's installation targets may
be propagated to main project. It's not what we are expecting.