### PR TITLE
Ensure std::{clog,cerr} streams can be formatted

### DIFF
--- a/test/test.cpp
+++ b/test/test.cpp
@@ -75,6 +75,12 @@ int main(int /*argc*/, char** /*argv*/)
     std::cout << concealed << "concealed message"  << reset << std::endl;
     std::cout << crossed   << "crossed message"    << reset << std::endl;
     std::cout              << "default message"    << std::endl;
+    std::cout << std::endl;
+
+    // test clog/cerr streams
+    std::clog << "formatted " << yellow << "std::clog" << reset << " message" << std::endl;
+    std::cerr << "formatted " << red    << "std::cerr" << reset << " message" << std::endl;
+    std::cout << std::endl;
 
     // test ansi escape characters are skipped for streams
     std::stringstream s1;


### PR DESCRIPTION
Add test statements to test.cpp in order to visually ensure that both
std::clog and std::cerr streams can be formatted to if they are attached
to tty.