### PR TITLE
Add 'std=c++11' compilation flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: cpp
 
 script:
-  - eval "CXX=${COMPILER}"
+  - eval "CXX=${COMPILER} CXXFLAGS=-std=c++11"
   - cmake -DTERMCOLOR_TESTS=ON .
   - cmake --build .
   - ./test_termcolor

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME} INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
+target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
 
 #
 # tests
@@ -20,12 +21,8 @@ option(TERMCOLOR_TESTS "Build termcolor tests." OFF)
 
 if(TERMCOLOR_TESTS)
   add_executable(test_${PROJECT_NAME} test/test.cpp)
-  target_compile_options(test_${PROJECT_NAME} INTERFACE
-    $<BUILD_INTERFACE:
-      $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:
-        -Werror -Wall -pedantic>>)
   target_link_libraries(
-    test_${PROJECT_NAME} PRIVATE ${PROJECT_NAME}::${PROJECT_NAME})
+    test_${PROJECT_NAME} ${PROJECT_NAME}::${PROJECT_NAME})
 endif()
 
 #


### PR DESCRIPTION
It's time to embrace the standard that is almost 10 yo. However, it's
weird that even modern compilers provide its features as an extensions
yet the code is not built according to C++11 standard. :-/