### PR TITLE
Require C++11 for examples/cmake-external

### DIFF
--- a/examples/cmake-external/CMakeLists.txt
+++ b/examples/cmake-external/CMakeLists.txt
@@ -12,6 +12,9 @@ ExternalProject_Add(termcolor_project
   # the hooks.
   CONFIGURE_COMMAND "" BUILD_COMMAND "" INSTALL_COMMAND "")
 ExternalProject_Get_Property(termcolor_project SOURCE_DIR)
+
+set(CMAKE_CXX_STANDARD 11)
+
 include_directories(${SOURCE_DIR}/include)
 add_library(termcolor INTERFACE IMPORTED)
 add_dependencies(termcolor termcolor_project)


### PR DESCRIPTION
All other examples are implicitly fetched C++11 requirements from
termcolor's cmake definition. This example, however, completely ignores
it and hence it's required to explicitly set one.