### PR TITLE
Share colorization flag between translation units

### DIFF
--- a/include/termcolor/termcolor.hpp
+++ b/include/termcolor/termcolor.hpp
@@ -48,10 +48,7 @@ namespace termcolor
     // All comments are below.
     namespace _internal
     {
-        // An index to be used to access a private storage of I/O streams. See
-        // colorize / nocolorize I/O manipulators for details.
-        static int colorize_index = std::ios_base::xalloc();
-
+        inline int colorize_index();
         inline FILE* get_standard_stream(const std::ostream& stream);
         inline bool is_colorized(std::ostream& stream);
         inline bool is_atty(const std::ostream& stream);
@@ -64,14 +61,14 @@ namespace termcolor
     inline
     std::ostream& colorize(std::ostream& stream)
     {
-        stream.iword(_internal::colorize_index) = 1L;
+        stream.iword(_internal::colorize_index()) = 1L;
         return stream;
     }
 
     inline
     std::ostream& nocolorize(std::ostream& stream)
     {
-        stream.iword(_internal::colorize_index) = 0L;
+        stream.iword(_internal::colorize_index()) = 0L;
         return stream;
     }
 
@@ -779,6 +776,17 @@ namespace termcolor
     //! the user code.
     namespace _internal
     {
+        // An index to be used to access a private storage of I/O streams. See
+        // colorize / nocolorize I/O manipulators for details. Due to the fact
+        // that static variables ain't shared between translation units, inline
+        // function with local static variable is used to do the trick and share
+        // the variable value between translation units.
+        inline int colorize_index()
+        {
+            static int colorize_index = std::ios_base::xalloc();
+            return colorize_index;
+        }
+
         //! Since C++ hasn't a true way to extract stream handler
         //! from the a given `std::ostream` object, I have to write
         //! this kind of hack.
@@ -799,7 +807,7 @@ namespace termcolor
         inline
         bool is_colorized(std::ostream& stream)
         {
-            return is_atty(stream) || static_cast<bool>(stream.iword(colorize_index));
+            return is_atty(stream) || static_cast<bool>(stream.iword(colorize_index()));
         }
 
         //! Test whether a given `std::ostream` object refers to


### PR DESCRIPTION
Termcolor is used to provide `colorize`/`nocolorize` stream manipulators
to colorize streams other than ones ties to TTY. Such streams are marked
by termcolor as capable to carry ASCII color codes. However, due to the
fact that the static variables are initialized per translation units, it
turns out that colorized stream returned by one translation unit to
another are not recognized as color capable. This patch makes things
right and ensures that the flag we use to store the marker is shared and
the same between translation units.

Fixes #54