### PR TITLE
Add macros based API

### DIFF
--- a/include/termcolor/termcolor.hpp
+++ b/include/termcolor/termcolor.hpp
@@ -12,34 +12,37 @@
 #ifndef TERMCOLOR_HPP_
 #define TERMCOLOR_HPP_
 
-// the following snippet of code detects the current OS and
-// defines the appropriate macro that is used to wrap some
-// platform specific things
+#include <iostream>
+#include <cstdio>
+
+// Detect target's platform and set some macros in order to wrap platform
+// specific code this library depends on.
 #if defined(_WIN32) || defined(_WIN64)
-#   define TERMCOLOR_OS_WINDOWS
-#elif defined(__APPLE__)
-#   define TERMCOLOR_OS_MACOS
-#elif defined(__unix__) || defined(__unix)
-#   define TERMCOLOR_OS_LINUX
-#else
-#   error unsupported platform
+#   define TERMCOLOR_TARGET_WINDOWS
+#elif defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))
+#   define TERMCOLOR_TARGET_POSIX
 #endif
 
+// If implementation has not been explicitly set, try to choose one based on
+// target platform.
+#if !defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES) && !defined(TERMCOLOR_USE_WINDOWS_API) && !defined(TERMCOLOR_USE_NOOP)
+#   if defined(TERMCOLOR_TARGET_POSIX)
+#       define TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES
+#       define TERMCOLOR_AUTODETECTED_IMPLEMENTATION
+#   elif defined(TERMCOLOR_TARGET_WINDOWS)
+#       define TERMCOLOR_USE_WINDOWS_API
+#       define TERMCOLOR_AUTODETECTED_IMPLEMENTATION
+#   endif
+#endif
 
-// This headers provides the `isatty()`/`fileno()` functions,
-// which are used for testing whether a standart stream refers
-// to the terminal. As for Windows, we also need WinApi funcs
-// for changing colors attributes of the terminal.
-#if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+// These headers provide isatty()/fileno() functions, which are used for
+// testing whether a standard stream refers to the terminal.
+#if defined(TERMCOLOR_TARGET_POSIX)
 #   include <unistd.h>
-#elif defined(TERMCOLOR_OS_WINDOWS)
+#elif defined(TERMCOLOR_TARGET_WINDOWS)
 #   include <io.h>
 #   include <windows.h>
 #endif
-
-
-#include <iostream>
-#include <cstdio>
 
 
 namespace termcolor
@@ -53,7 +56,7 @@ namespace termcolor
         inline bool is_colorized(std::ostream& stream);
         inline bool is_atty(const std::ostream& stream);
 
-    #if defined(TERMCOLOR_OS_WINDOWS)
+    #if defined(TERMCOLOR_TARGET_WINDOWS)
         inline void win_change_attributes(std::ostream& stream, int foreground, int background=-1);
     #endif
     }
@@ -77,9 +80,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[00m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream, -1, -1);
         #endif
         }
@@ -91,9 +94,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[1m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
         #endif
         }
         return stream;
@@ -104,9 +107,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[2m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
         #endif
         }
         return stream;
@@ -117,9 +120,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[3m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
         #endif
         }
         return stream;
@@ -130,9 +133,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[4m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream, -1, COMMON_LVB_UNDERSCORE);
         #endif
         }
@@ -144,9 +147,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[5m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
         #endif
         }
         return stream;
@@ -157,9 +160,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[7m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
         #endif
         }
         return stream;
@@ -170,9 +173,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[8m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
         #endif
         }
         return stream;
@@ -183,9 +186,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[9m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
         #endif
         }
         return stream;
@@ -196,11 +199,11 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             char command[12];
             std::snprintf(command, sizeof(command), "\033[38;5;%dm", code);
             stream << command;
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
         #endif
         }
         return stream;
@@ -211,11 +214,11 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             char command[12];
             std::snprintf(command, sizeof(command), "\033[48;5;%dm", code);
             stream << command;
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
         #endif
         }
         return stream;
@@ -226,11 +229,11 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             char command[20];
             std::snprintf(command, sizeof(command), "\033[38;2;%d;%d;%dm", r, g, b);
             stream << command;
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
         #endif
         }
         return stream;
@@ -241,11 +244,11 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             char command[20];
             std::snprintf(command, sizeof(command), "\033[48;2;%d;%d;%dm", r, g, b);
             stream << command;
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
         #endif
         }
         return stream;
@@ -256,9 +259,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[30m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream,
                 0   // grey (black)
             );
@@ -272,9 +275,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[31m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream,
                 FOREGROUND_RED
             );
@@ -288,9 +291,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[32m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream,
                 FOREGROUND_GREEN
             );
@@ -304,9 +307,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[33m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream,
                 FOREGROUND_GREEN | FOREGROUND_RED
             );
@@ -320,9 +323,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[34m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream,
                 FOREGROUND_BLUE
             );
@@ -336,9 +339,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[35m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream,
                 FOREGROUND_BLUE | FOREGROUND_RED
             );
@@ -352,9 +355,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[36m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream,
                 FOREGROUND_BLUE | FOREGROUND_GREEN
             );
@@ -368,9 +371,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[37m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream,
                 FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED
             );
@@ -385,9 +388,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[90m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream,
                 0 | FOREGROUND_INTENSITY   // grey (black)
             );
@@ -401,9 +404,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[91m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream,
                 FOREGROUND_RED | FOREGROUND_INTENSITY
             );
@@ -417,9 +420,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[92m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream,
                 FOREGROUND_GREEN | FOREGROUND_INTENSITY
             );
@@ -433,9 +436,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[93m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream,
                 FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_INTENSITY
             );
@@ -449,9 +452,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[94m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream,
                 FOREGROUND_BLUE | FOREGROUND_INTENSITY
             );
@@ -465,9 +468,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[95m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream,
                 FOREGROUND_BLUE | FOREGROUND_RED | FOREGROUND_INTENSITY
             );
@@ -481,9 +484,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[96m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream,
                 FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_INTENSITY
             );
@@ -497,9 +500,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[97m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream,
                 FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_INTENSITY
             );
@@ -514,9 +517,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[40m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream, -1,
                 0   // grey (black)
             );
@@ -530,9 +533,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[41m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream, -1,
                 BACKGROUND_RED
             );
@@ -546,9 +549,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[42m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream, -1,
                 BACKGROUND_GREEN
             );
@@ -562,9 +565,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[43m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream, -1,
                 BACKGROUND_GREEN | BACKGROUND_RED
             );
@@ -578,9 +581,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[44m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream, -1,
                 BACKGROUND_BLUE
             );
@@ -594,9 +597,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[45m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream, -1,
                 BACKGROUND_BLUE | BACKGROUND_RED
             );
@@ -610,9 +613,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[46m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream, -1,
                 BACKGROUND_GREEN | BACKGROUND_BLUE
             );
@@ -626,9 +629,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[47m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream, -1,
                 BACKGROUND_GREEN | BACKGROUND_BLUE | BACKGROUND_RED
             );
@@ -644,9 +647,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[100m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream, -1,
                 0 | BACKGROUND_INTENSITY   // grey (black)
             );
@@ -660,9 +663,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[101m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream, -1,
                 BACKGROUND_RED | BACKGROUND_INTENSITY
             );
@@ -676,9 +679,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[102m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream, -1,
                 BACKGROUND_GREEN | BACKGROUND_INTENSITY
             );
@@ -692,9 +695,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[103m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream, -1,
                 BACKGROUND_GREEN | BACKGROUND_RED | BACKGROUND_INTENSITY
             );
@@ -708,9 +711,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[104m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream, -1,
                 BACKGROUND_BLUE | BACKGROUND_INTENSITY
             );
@@ -724,9 +727,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[105m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream, -1,
                 BACKGROUND_BLUE | BACKGROUND_RED | BACKGROUND_INTENSITY
             );
@@ -740,9 +743,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[106m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream, -1,
                 BACKGROUND_GREEN | BACKGROUND_BLUE | BACKGROUND_INTENSITY
             );
@@ -756,9 +759,9 @@ namespace termcolor
     {
         if (_internal::is_colorized(stream))
         {
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES)
             stream << "\033[107m";
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_USE_WINDOWS_API)
             _internal::win_change_attributes(stream, -1,
                 BACKGROUND_GREEN | BACKGROUND_BLUE | BACKGROUND_RED | BACKGROUND_INTENSITY
             );
@@ -824,14 +827,16 @@ namespace termcolor
             if (!std_stream)
                 return false;
 
-        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+        #if defined(TERMCOLOR_TARGET_POSIX)
             return ::isatty(fileno(std_stream));
-        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #elif defined(TERMCOLOR_TARGET_WINDOWS)
             return ::_isatty(_fileno(std_stream));
+        #else
+            return false;
         #endif
         }
 
-    #if defined(TERMCOLOR_OS_WINDOWS)
+    #if defined(TERMCOLOR_TARGET_WINDOWS)
         //! Change Windows Terminal colors attribute. If some
         //! parameter is `-1` then attribute won't changed.
         inline void win_change_attributes(std::ostream& stream, int foreground, int background)
@@ -888,15 +893,19 @@ namespace termcolor
 
             SetConsoleTextAttribute(hTerminal, info.wAttributes);
         }
-    #endif // TERMCOLOR_OS_WINDOWS
+    #endif // TERMCOLOR_TARGET_WINDOWS
 
     } // namespace _internal
 
 } // namespace termcolor
 
 
-#undef TERMCOLOR_OS_WINDOWS
-#undef TERMCOLOR_OS_MACOS
-#undef TERMCOLOR_OS_LINUX
+#undef TERMCOLOR_TARGET_POSIX
+#undef TERMCOLOR_TARGET_WINDOWS
+
+#if defined(TERMCOLOR_AUTODETECTED_IMPLEMENTATION)
+#   undef TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES
+#   undef TERMCOLOR_USE_WINDOWS_API
+#endif
 
 #endif // TERMCOLOR_HPP_


### PR DESCRIPTION
In order to address a bunch of edge cases this patch introduces a set of
new macros to control Termcolor's behaviour in certain situations. See
changes summary below.

 * Termcolor used to abort compilation if unsupported target platform is
   detected. This patch changes this behaviour since colorization is not
   assumed to be essential and hence it's better to noop rather than
   abort compilation.

 * Termcolor used to always use Windows API when target OS is Windows.
   Now one can define TERMCOLOR_USE_ANSI_ESCAPE_SEQUENCES in order to
   enforce ANSI escape sequences even for Windows. This is useful when
   one wants to use ANSI escape sequences on Windows 10.

   https://docs.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences

 * Termcolor used to always colorize output if the platform is detected.
   Now one can define TERMCOLOR_USE_NOOP to turn off colorization and
   trick termcolor to be noop.

Closes #22
Closes #29
Closes #49