### PR TITLE
Added CMake versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,11 @@ configure_package_config_file(
   ${CMAKE_CURRENT_BINARY_DIR}/generated/${PROJECT_NAME}-config.cmake
   INSTALL_DESTINATION lib/cmake/${PROJECT_NAME})
 
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/generated/${PROJECT_NAME}-config-version.cmake
+  VERSION 2.0.0
+  COMPATIBILITY SameMajorVersion)
+
 install(
   FILES ${CMAKE_CURRENT_BINARY_DIR}/generated/${PROJECT_NAME}-config.cmake
   DESTINATION lib/cmake/${PROJECT_NAME})


### PR DESCRIPTION
Hey, this is all tested (I built it and installed and everything).
The difference just allows users to specify version in CMake:
```CMake
find_package(termcolor 2.0.0 REQUIRED)
```
Its just three lines in [CMakeLists.txt]() that specify the `write_basic_package_version_file` helper. 

https://github.com/HunterKohler/termcolor/blob/c37fd7f95c6532cecdb693f99fda15f1072a04d9/CMakeLists.txt#L39-L42

I made sure to add `/generated` to the path as you guys have been doing. Thus, the generated file `termcolor-config-verion.cmake`.