### PR TITLE
Strip inline attribute from templates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_11)
 option(TERMCOLOR_TESTS "Build termcolor tests." OFF)
 
 if(TERMCOLOR_TESTS)
-  add_executable(test_${PROJECT_NAME} test/test.cpp)
+  add_executable(test_${PROJECT_NAME} test/test.cpp test/subtest.cpp)
   target_link_libraries(
     test_${PROJECT_NAME} ${PROJECT_NAME}::${PROJECT_NAME})
 endif()

--- a/include/termcolor/termcolor.hpp
+++ b/include/termcolor/termcolor.hpp
@@ -54,18 +54,17 @@ namespace termcolor
         inline FILE* get_standard_stream(const std::ostream& stream);
         inline FILE* get_standard_stream(const std::wostream& stream);
         template <typename CharT>
-        inline bool is_colorized(std::basic_ostream<CharT>& stream);
+        bool is_colorized(std::basic_ostream<CharT>& stream);
         template <typename CharT>
-        inline bool is_atty(const std::basic_ostream<CharT>& stream);
+        bool is_atty(const std::basic_ostream<CharT>& stream);
 
     #if defined(TERMCOLOR_TARGET_WINDOWS)
         template <typename CharT>
-        inline void win_change_attributes(std::basic_ostream<CharT>& stream, int foreground, int background = -1);
+        void win_change_attributes(std::basic_ostream<CharT>& stream, int foreground, int background = -1);
     #endif
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& colorize(std::basic_ostream<CharT>& stream)
     {
         stream.iword(_internal::colorize_index()) = 1L;
@@ -73,7 +72,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& nocolorize(std::basic_ostream<CharT>& stream)
     {
         stream.iword(_internal::colorize_index()) = 0L;
@@ -81,7 +79,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& reset(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -96,7 +93,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& bold(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -110,7 +106,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& dark(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -124,7 +119,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& italic(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -138,7 +132,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& underline(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -153,7 +146,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& blink(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -167,7 +159,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& reverse(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -181,7 +172,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& concealed(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -195,7 +185,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& crossed(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -209,7 +198,6 @@ namespace termcolor
     }
     
     template <uint8_t code, typename CharT>
-    inline
     std::basic_ostream<CharT>& color(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -223,7 +211,6 @@ namespace termcolor
     }
 
     template <uint8_t code, typename CharT>
-    inline
     std::basic_ostream<CharT>& on_color(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -237,7 +224,6 @@ namespace termcolor
     }
 
     template <uint8_t r, uint8_t g, uint8_t b, typename CharT>
-    inline
     std::basic_ostream<CharT>& color(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -251,7 +237,6 @@ namespace termcolor
     }
 
     template <uint8_t r, uint8_t g, uint8_t b, typename CharT>
-    inline
     std::basic_ostream<CharT>& on_color(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -265,7 +250,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& grey(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -282,7 +266,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& red(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -299,7 +282,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& green(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -316,7 +298,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& yellow(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -333,7 +314,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& blue(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -350,7 +330,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& magenta(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -367,7 +346,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& cyan(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -384,7 +362,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& white(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -402,7 +379,6 @@ namespace termcolor
 
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& bright_grey(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -419,7 +395,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& bright_red(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -436,7 +411,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& bright_green(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -453,7 +427,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& bright_yellow(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -470,7 +443,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& bright_blue(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -487,7 +459,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& bright_magenta(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -504,7 +475,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& bright_cyan(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -521,7 +491,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& bright_white(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -539,7 +508,6 @@ namespace termcolor
 
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& on_grey(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -556,7 +524,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& on_red(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -573,7 +540,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& on_green(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -590,7 +556,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& on_yellow(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -607,7 +572,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& on_blue(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -624,7 +588,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& on_magenta(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -641,7 +604,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& on_cyan(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -658,7 +620,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& on_white(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -677,7 +638,6 @@ namespace termcolor
 
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& on_bright_grey(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -694,7 +654,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& on_bright_red(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -711,7 +670,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& on_bright_green(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -728,7 +686,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& on_bright_yellow(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -745,7 +702,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& on_bright_blue(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -762,7 +718,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& on_bright_magenta(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -779,7 +734,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& on_bright_cyan(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -796,7 +750,6 @@ namespace termcolor
     }
 
     template <typename CharT>
-    inline
     std::basic_ostream<CharT>& on_bright_white(std::basic_ostream<CharT>& stream)
     {
         if (_internal::is_colorized(stream))
@@ -864,7 +817,6 @@ namespace termcolor
         // true for ATTY streams and may be true for streams marked with
         // colorize flag.
         template <typename CharT>
-        inline
         bool is_colorized(std::basic_ostream<CharT>& stream)
         {
             return is_atty(stream) || static_cast<bool>(stream.iword(colorize_index()));
@@ -873,7 +825,6 @@ namespace termcolor
         //! Test whether a given `std::ostream` object refers to
         //! a terminal.
         template <typename CharT>
-        inline
         bool is_atty(const std::basic_ostream<CharT>& stream)
         {
             FILE* std_stream = get_standard_stream(stream);
@@ -919,7 +870,7 @@ namespace termcolor
         //! Change Windows Terminal colors attribute. If some
         //! parameter is `-1` then attribute won't changed.
         template <typename CharT>
-        inline void win_change_attributes(std::basic_ostream<CharT>& stream, int foreground, int background)
+        void win_change_attributes(std::basic_ostream<CharT>& stream, int foreground, int background)
         {
             // yeah, i know.. it's ugly, it's windows.
             static WORD defaultAttributes = 0;

--- a/test/subtest.cpp
+++ b/test/subtest.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+#include "termcolor/termcolor.hpp"
+
+
+void subtest_from_another_tranlation_unit()
+{
+    std::cout << termcolor::blue << "subtest" << termcolor::reset << std::endl;
+}

--- a/test/subtest.hpp
+++ b/test/subtest.hpp
@@ -1,0 +1,6 @@
+#ifndef SUBTEST_HPP_
+#define SUBTEST_HPP_
+
+void subtest_from_another_tranlation_unit();
+
+#endif // SUBTEST_HPP_

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -34,6 +34,7 @@
 #   include <sstream>
 #endif
 #include "termcolor/termcolor.hpp"
+#include "subtest.hpp"
 
 using namespace termcolor;
 
@@ -130,6 +131,9 @@ int main(int /*argc*/, char** /*argv*/)
     std::clog << "formatted " << yellow << "std::clog" << reset << " message" << std::endl;
     std::cerr << "formatted " << red    << "std::cerr" << reset << " message" << std::endl;
     std::cout << std::endl;
+
+    // test another translation unit
+    subtest_from_another_tranlation_unit();
 
     // test ansi escape characters are skipped for streams
     std::stringstream s1;


### PR DESCRIPTION
The `inline` attribute has initially been used as a workaround to allow
function definitions in the header file. Templates are defined in
headers by design which means there's no need for `inline` attribute
anymore.