### PR TITLE
Do not export install commands if termcolor is a subproject.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
 cmake_minimum_required(VERSION 3.0)
+
+if(DEFINED PROJECT_NAME)
+  set(TERMCOLOR_SUBPROJECT ON)
+endif()
+
 project(termcolor)
 
 #
@@ -29,30 +34,32 @@ endif()
 # install
 #
 
-include(CMakePackageConfigHelpers)
+if(NOT TERMCOLOR_SUBPROJECT)
+  include(CMakePackageConfigHelpers)
 
-# Installation paths
-include(GNUInstallDirs)
+  # Installation paths
+  include(GNUInstallDirs)
 
-configure_package_config_file(
-  cmake/config.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/generated/${PROJECT_NAME}-config.cmake
-  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+  configure_package_config_file(
+    cmake/config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/generated/${PROJECT_NAME}-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+  
+  install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/generated/${PROJECT_NAME}-config.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
-install(
-  FILES ${CMAKE_CURRENT_BINARY_DIR}/generated/${PROJECT_NAME}-config.cmake
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+  install(
+    DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-install(
-  DIRECTORY include/
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(
+    TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}-targets
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-install(
-  TARGETS ${PROJECT_NAME}
-  EXPORT ${PROJECT_NAME}-targets
-  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
-install(
-  EXPORT ${PROJECT_NAME}-targets
-  NAMESPACE ${PROJECT_NAME}::
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+  install(
+    EXPORT ${PROJECT_NAME}-targets
+    NAMESPACE ${PROJECT_NAME}::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+endif()


### PR DESCRIPTION
If termcolor is used as a subproject (e.g. via cpm package manager or via fetch_content()) the install calls should be hidden. This can be achieved by guarding the calls with:
 
```
if(NOT TERMCOLOR_SUBPROJECT)
  install(...)
endif()
```

The variable `TERMCOLOR_SUBPROJECT` can be determined at the beginning of the CMakeLists.txt by checking if another `project()` call is present.