### PR TITLE
GCC13 compatibility: Explicitly include cstdint

### DIFF
--- a/include/termcolor/termcolor.hpp
+++ b/include/termcolor/termcolor.hpp
@@ -12,6 +12,7 @@
 #ifndef TERMCOLOR_HPP_
 #define TERMCOLOR_HPP_
 
+#include <cstdint>
 #include <iostream>
 
 // Detect target's platform and set some macros in order to wrap platform


### PR DESCRIPTION
GCC13 reduced the amount of implicitly included headers (see https://gcc.gnu.org/gcc-13/porting_to.html). To compile termcolor with GCC13, cstdint now needs to be explicity included.

Explicitly including a header that was included implicitly before should normally not change the behaviour on other platforms or when building with a different compiler, but I can't check them all.