### PR TITLE
CMake: Allow install if non-toplevel project.

### DIFF
--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -1,4 +1,4 @@
 @PACKAGE_INIT@
 
-include("${CMAKE_CURRENT_LIST_DIR}/@CMAKE_PROJECT_NAME@-targets.cmake")
-check_required_components("@CMAKE_PROJECT_NAME@")
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
+check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
If another project vendors termcolor (via `add_subdirectory`) and tries to install, the resulting package is not usable. 
Let's say the top level project has a CMakeLists.txt like this:

```
cmake_minimum_required(VERSION 3.20)

project(my_project)
add_subdirectory(termcolor)
```

The generated `termcolor-config.cmake` will want to include `my_project-targets.cmake` instead of `termcolor-targets.cmake`.

By changing `CMAKE_PROJECT_NAME` to `PROJECT_NAME` in `config.cmake.in` this problem is solved.