### PR TITLE
fixing uint32_t was not declared

### DIFF
--- a/include/termcolor/termcolor.hpp
+++ b/include/termcolor/termcolor.hpp
@@ -13,6 +13,7 @@
 #define TERMCOLOR_HPP_
 
 #include <iostream>
+#include <stdint.h>
 
 // Detect target's platform and set some macros in order to wrap platform
 // specific code this library depends on.


### PR DESCRIPTION
the compiler stopped and give me that error.
[C++ 11] [GCC]

just a single `#Include` was missing.
*Note: please declare which c++ version you are targeting*